### PR TITLE
Change HTTP status code response for invalid parameters from 500 to 400

### DIFF
--- a/1.3/openapi/paths/tickers.yml
+++ b/1.3/openapi/paths/tickers.yml
@@ -56,5 +56,5 @@ tickers_historical:
               $ref: "../schemas/tickers.yml#/historical_ticks"
       429:
         description: "too many requests"
-      500:
+      400:
         description: "invalid parameters"

--- a/1.4/openapi/paths/tickers.yml
+++ b/1.4/openapi/paths/tickers.yml
@@ -56,5 +56,5 @@ tickers_historical:
               $ref: "../schemas/tickers.yml#/historical_ticks"
       429:
         description: "too many requests"
-      500:
+      400:
         description: "invalid parameters"

--- a/1.5/openapi/paths/tickers.yml
+++ b/1.5/openapi/paths/tickers.yml
@@ -56,5 +56,5 @@ tickers_historical:
               $ref: "../schemas/tickers.yml#/historical_ticks"
       429:
         description: "too many requests"
-      500:
+      400:
         description: "invalid parameters"


### PR DESCRIPTION
The [API documentation](https://api.coinpaprika.com/#tag/Tickers/paths/~1tickers~1{coin_id}~1historical/get) for endpoint `/tickers/coin_id/historical` indicates that a HTTP `500` status code is returned if the parameters are invalid, whilst it returns `400` and is documented as such for other endpoints. This pull request fixes the typo.