### PR TITLE
Refresh 1.7 openapi: current plan limits, Ultimate row, api-pro server

### DIFF
--- a/1.7/openapi/index.yml
+++ b/1.7/openapi/index.yml
@@ -25,6 +25,7 @@ info:
     | Starter    | https://api-pro.coinpaprika.com/v1/ |
     | Pro        | https://api-pro.coinpaprika.com/v1/ |
     | Business   | https://api-pro.coinpaprika.com/v1/ |
+    | Ultimate   | https://api-pro.coinpaprika.com/v1/ |
     | Enterprise | https://api-pro.coinpaprika.com/v1/ |
 
     # Authentication
@@ -63,9 +64,10 @@ info:
       | Plan       | Calls/month                         |
       |------------|-------------------------------------|
       | Free       | 20 000 |
-      | Starter    | 200 000 |
-      | Pro        | 500 000 |
-      | Business   | 3 000 000 |
+      | Starter    | 400 000 |
+      | Pro        | 1 000 000 |
+      | Business   | 5 000 000 |
+      | Ultimate   | 10 000 000 |
       | Enterprise | No limits |
 
     # API Clients
@@ -94,6 +96,10 @@ info:
     * [API v1.5](https://api.coinpaprika.com/docs/1.5)
     * [API v1.6](https://api.coinpaprika.com/docs/1.6)
     # Version history
+    ## 1.7.11 - 2026.05.05
+    * Refreshed plan / rate-limit table to match current pricing (Starter 400k, Pro 1M, Business 5M, Ultimate 10M)
+    * Added Ultimate plan row to base-URL and rate-limit tables
+    * Added `api-pro.coinpaprika.com/v1` to the `servers:` block so codegen produces clients that can hit paid endpoints
     ## 1.7.10 - 2025.04.14
     * Added `5m` interval for historical OHLCV endpoint
     ## 1.7.9 - 2024.12.18
@@ -126,6 +132,9 @@ info:
 
 servers:
 - url: https://api.coinpaprika.com/v1
+  description: Free plan
+- url: https://api-pro.coinpaprika.com/v1
+  description: Paid plans (Starter, Pro, Business, Ultimate, Enterprise)
 
 tags:
 - name: "Key"


### PR DESCRIPTION
## What this fixes

`coinpaprika.github.io/1.7/openapi/index.yml` is the legacy Stoplight openapi source still indexed by search engines (and used as input to a few codegen tools). It went stale on three things:

1. **Plan / rate-limit table** lists outdated monthly call counts:

   | Plan       | Was        | Now        |
   |------------|------------|------------|
   | Starter    | 200 000    | 400 000    |
   | Pro        | 500 000    | 1 000 000  |
   | Business   | 3 000 000  | 5 000 000  |
   | Ultimate   | (missing)  | 10 000 000 |

2. **Base-URL table** is missing the Ultimate row.

3. **`servers:` block** only declares `api.coinpaprika.com/v1`. Anyone codegen'ing a client from this spec gets a free-tier-only client that cannot hit paid endpoints.

The page banner already says "NEW DOCUMENTATION AVAILABLE" pointing at `docs.coinpaprika.com`, but this URL is still indexed and people land on it from search. Until/unless we 301 the page, the data here should be accurate.

## Changes

- Add `Ultimate` row to the base-URL table
- Refresh the plan / rate-limit table to current pricing
- Add `api-pro.coinpaprika.com/v1` (with description) to the `servers:` block alongside the existing free server
- Bump version history to `1.7.11`